### PR TITLE
Coerce "hub pull-request" to properly detect the tracking branch

### DIFF
--- a/sync-with-upstream/entrypoint.sh
+++ b/sync-with-upstream/entrypoint.sh
@@ -35,7 +35,13 @@ git branch --set-upstream-to "origin/${DOWNSTREAM_BRANCH}"
 git reset --hard "origin/${DOWNSTREAM_BRANCH}"
 
 git merge "upstream/${UPSTREAM_BRANCH}"
-git push -f origin "HEAD:projects/sync-with-upstream/${DOWNSTREAM_BRANCH}"
+
+#
+# In order for the "hub" command to properly detect which remote branch
+# is the "tracking" branch, we must use "-u" here such that the local
+# branch tracks the remote branch we're pushing to.
+#
+git push -f -u origin "HEAD:projects/sync-with-upstream/${DOWNSTREAM_BRANCH}"
 
 #
 # We remove this remote that we added before so the "hub" command can
@@ -43,6 +49,14 @@ git push -f origin "HEAD:projects/sync-with-upstream/${DOWNSTREAM_BRANCH}"
 # so it'll open the pull request against the "origin" repository.
 #
 git remote remove upstream
+
+#
+# In order for the "hub" command to work properly when generating the
+# pull request, we need to set this git configuration. This way, "hub"
+# will not incorrectly assume any remote branch named the same as the
+# local branch, is the tracking branch.
+#
+git config push.default upstream
 
 #
 # Opening a pull request may fail if there already exists a pull request


### PR DESCRIPTION
When opening a pull request with "hub", the command will attempt to be
helpful and try to detect when the local branch contains commits that
are not present in the remote branch that'll be used for the pull
request. This is so that it's more difficult to open a pull request,
only to find out it doesn't contain all fo the intended commits; e.g.
because some commits weren't pushed to the remote branch.

In order for this check to work properly in our case, we need to ensure
it's checking the branch we push to under the "sync-with-upstream"
namespace. We (now) do this by setting the local branch's tracking
branch to point to that remote branch, and also by setting the
"push.default" git configuration tunable. The "hub" command currently
checks that tunable and modifies it's behavior based on that value.

By default, the "hub" command would detect a remote branch with the same
name as the local branch, and assume that branch was the local branch's
remote tracking branch; which is not the case for this script, and could
result in "hub pull-request" throwing an error like the following:

    + hub pull-request -F - -b master -h projects/sync-with-upstream/master
    Aborted: 1 commits are not yet pushed to origin/master
    (use `-f` to force submit a pull request anyway)