### PR TITLE
sync-with-upstream: do nothing if workflow PR already exists

### DIFF
--- a/sync-with-upstream/entrypoint.sh
+++ b/sync-with-upstream/entrypoint.sh
@@ -12,6 +12,23 @@ DOWNSTREAM_BRANCH="$3"
 [[ -n "${DOWNSTREAM_BRANCH}" ]] || exit 1
 
 #
+# If there is a PR already then this is a no-op.
+#
+# An alternative design would be to pile up more commits
+# from the upstream repo if there exist any into the
+# existing PR instead of exiting here. (e.g. we could
+# check the hash of the upstream HEAD and see if that
+# hash is part of the existing PR, and if it's not we'd
+# force push into the PR). We decided not to go with
+# that design due to the simplicity of the current one.
+#
+SYNC_PR=$(hub pr list -s open -h "projects/sync-with-upstream/${DOWNSTREAM_BRANCH}")
+if [[ -n "${SYNC_PR}" ]]; then
+	echo "sync-with-upstream PR already exists: ${SYNC_PR}"
+	exit 0
+fi
+
+#
 # We need these config parameters set in order to do the git-merge.
 #
 git config user.name "${GITHUB_ACTOR}"


### PR DESCRIPTION
We recently noticed that the specific workflow fails once a PR
for it has already been opened but hasn't been merged. The
problem is that with the current branch protections standards
of Delphix repos on Github we are not allowed to force-push to
the downstream branch. Assuming no re-writes in the history of
the upstream repo, this commit avoids force-pushing in this
workflow by only pushing code to the downstream branch when
there is no open PR for it.

= Testing:

I tested this in a copy of the savedump repo that I made here: https://github.com/sdimitro/savedump-workflows

Step 1 = No differences between upstream and downstream branches
job - https://github.com/sdimitro/savedump-workflows/runs/1063201884?check_suite_focus=true
result - no differences, no PR, no problem

Step 2 = Upstream has 1 new commit:
job - https://github.com/sdimitro/savedump-workflows/runs/1063358249?check_suite_focus=true
New PR - https://github.com/sdimitro/savedump-workflows/pull/2
result - PR was created by the job to merge this new commit to downstream master

Step 3 = Upstream got another commit but we haven't merged the existing PR  downstream yet:
job - https://github.com/sdimitro/savedump-workflows/runs/1063385439?check_suite_focus=true
result - The PR created in Step 2 is exactly the same as before

Step 4 = Merge PR from Step 3:
job - https://github.com/sdimitro/savedump-workflows/runs/1063414136?check_suite_focus=true
PR - https://github.com/sdimitro/savedump-workflows/pull/3
result - After waiting for the job to kick in again, we see that another PR was opened with the second change